### PR TITLE
add weights folding

### DIFF
--- a/model_diffing/models/crosscoder.py
+++ b/model_diffing/models/crosscoder.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
+from contextlib import contextmanager
 from dataclasses import dataclass
+from typing import cast
 
 import torch as t
 from einops import einsum, rearrange, reduce
@@ -51,6 +53,10 @@ class BatchTopkActivation(nn.Module):
 class AcausalCrosscoder(nn.Module):
     """crosscoder that autoencodes activations of a subset of a model's layers"""
 
+    folded_scaling_factors_ML: t.Tensor | None
+    """Scaling factors that have been folded into the weights, if any"""
+
+    #
     def __init__(
         self,
         n_models: int,
@@ -82,6 +88,8 @@ class AcausalCrosscoder(nn.Module):
         self.b_dec_MLD = nn.Parameter(t.zeros((n_models, n_layers, d_model)))
         self.b_enc_H = nn.Parameter(t.zeros((hidden_dim,)))
 
+        self.register_buffer("folded_scaling_factors_ML", None, persistent=True)
+
     def encode(self, activation_BMLD: t.Tensor) -> t.Tensor:
         hidden_BH = einsum(
             activation_BMLD,
@@ -110,23 +118,79 @@ class AcausalCrosscoder(nn.Module):
         activation_BMLD: t.Tensor,
     ) -> TrainResult:
         """returns the activations, the hidden states, and the reconstructed activations"""
-        assert activation_BMLD.shape[1:] == self.activations_shape_MLD, (
-            f"activation_BMLD.shape[1:] {activation_BMLD.shape[1:]} != "
-            f"self.activations_shape_MLD {self.activations_shape_MLD}"
-        )
+        self._validate_acts_shape(activation_BMLD)
+
         hidden_BH = self.encode(activation_BMLD)
         reconstructed_BMLD = self.decode(hidden_BH)
-        assert reconstructed_BMLD.shape == activation_BMLD.shape
-        assert len(reconstructed_BMLD.shape) == 4
+
+        if reconstructed_BMLD.shape != activation_BMLD.shape:
+            raise ValueError(
+                f"reconstructed_BMLD.shape {reconstructed_BMLD.shape} != activation_BMLD.shape {activation_BMLD.shape}"
+            )
 
         return self.TrainResult(
             hidden_BH=hidden_BH,
             reconstructed_acts_BMLD=reconstructed_BMLD,
         )
 
+    def _validate_acts_shape(self, activation_BMLD: t.Tensor) -> None:
+        if activation_BMLD.shape[1:] != self.activations_shape_MLD:
+            raise ValueError(
+                f"activation_BMLD.shape[1:] {activation_BMLD.shape[1:]} != "
+                f"self.activations_shape_MLD {self.activations_shape_MLD}"
+            )
+
     def forward(self, activation_BMLD: t.Tensor) -> t.Tensor:
         hidden_BH = self.encode(activation_BMLD)
         return self.decode(hidden_BH)
+
+    @property
+    def is_folded(self) -> bool:
+        return self.folded_scaling_factors_ML is not None
+
+    def fold_activation_scaling_into_weights(self, activation_scaling_factors_ML: t.Tensor) -> None:
+        """scales the crosscoder weights by the activation scaling factors, so that the model can be run on raw llm activations."""
+        if self.is_folded:
+            raise ValueError("Scaling factors already folded into weights")
+
+        self._validate_scaling_factors(activation_scaling_factors_ML)
+        activation_scaling_factors_ML = activation_scaling_factors_ML.to(self.W_enc_MLDH.device)
+        self._scale_weights(activation_scaling_factors_ML)
+        # set buffer to prevent double-folding
+        self.folded_scaling_factors_ML = activation_scaling_factors_ML
+
+    def unfold_activation_scaling_from_weights(self) -> t.Tensor:
+        if not self.is_folded:
+            raise ValueError("No folded scaling factors found")
+
+        folded_scaling_factors_ML = cast(t.Tensor, self.folded_scaling_factors_ML).clone()
+        # Clear the buffer before operations to prevent double-unfolding
+        self.folded_scaling_factors_ML = None
+        self._scale_weights(1 / folded_scaling_factors_ML)
+        return folded_scaling_factors_ML
+
+    @t.no_grad()
+    def _scale_weights(self, scaling_factors_ML: t.Tensor) -> None:
+        self.W_enc_MLDH.mul_(scaling_factors_ML[..., None, None])
+        self.W_dec_HMLD.div_(scaling_factors_ML[..., None])
+        self.b_dec_MLD.div_(scaling_factors_ML[..., None])
+
+    def _validate_scaling_factors(self, scaling_factors_ML: t.Tensor) -> None:
+        if t.any(scaling_factors_ML == 0):
+            raise ValueError("Scaling factors contain zeros, which would lead to division by zero")
+        if t.any(t.isnan(scaling_factors_ML)) or t.any(t.isinf(scaling_factors_ML)):
+            raise ValueError("Scaling factors contain NaN or Inf values")
+
+        expected_shape = (self.activations_shape_MLD[0], self.activations_shape_MLD[1])
+        if scaling_factors_ML.shape != expected_shape:
+            raise ValueError(f"Expected shape {expected_shape}, got {scaling_factors_ML.shape}")
+
+    @contextmanager
+    def temporary_fold(self, scaling_factors: t.Tensor):
+        """Temporarily fold scaling factors into weights."""
+        self.fold_activation_scaling_into_weights(scaling_factors)
+        yield
+        _ = self.unfold_activation_scaling_from_weights()
 
 
 def build_relu_crosscoder(

--- a/model_diffing/models/crosscoder.py
+++ b/model_diffing/models/crosscoder.py
@@ -148,7 +148,7 @@ class AcausalCrosscoder(nn.Module):
     def is_folded(self) -> bool:
         return self.folded_scaling_factors_ML is not None
 
-    def fold_activation_scaling_into_weights(self, activation_scaling_factors_ML: t.Tensor) -> None:
+    def fold_activation_scaling_into_weights_(self, activation_scaling_factors_ML: t.Tensor) -> None:
         """scales the crosscoder weights by the activation scaling factors, so that the model can be run on raw llm activations."""
         if self.is_folded:
             raise ValueError("Scaling factors already folded into weights")
@@ -159,7 +159,7 @@ class AcausalCrosscoder(nn.Module):
         # set buffer to prevent double-folding
         self.folded_scaling_factors_ML = activation_scaling_factors_ML
 
-    def unfold_activation_scaling_from_weights(self) -> t.Tensor:
+    def unfold_activation_scaling_from_weights_(self) -> t.Tensor:
         if not self.is_folded:
             raise ValueError("No folded scaling factors found")
 
@@ -188,9 +188,9 @@ class AcausalCrosscoder(nn.Module):
     @contextmanager
     def temporary_fold(self, scaling_factors: t.Tensor):
         """Temporarily fold scaling factors into weights."""
-        self.fold_activation_scaling_into_weights(scaling_factors)
+        self.fold_activation_scaling_into_weights_(scaling_factors)
         yield
-        _ = self.unfold_activation_scaling_from_weights()
+        _ = self.unfold_activation_scaling_from_weights_()
 
 
 def build_relu_crosscoder(

--- a/model_diffing/models/crosscoder.py
+++ b/model_diffing/models/crosscoder.py
@@ -34,13 +34,13 @@ class TopkActivation(nn.Module):
 
 # ! this is not tested yet
 class BatchTopkActivation(nn.Module):
-    def __init__(self, k: int):
+    def __init__(self, k_per_example: int):
         super().__init__()
-        self.k = k
+        self.k_per_example = k_per_example
 
     def forward(self, hidden_preactivation_BH: t.Tensor) -> t.Tensor:
         batch_size = hidden_preactivation_BH.shape[0]
-        batch_k = self.k * batch_size
+        batch_k = self.k_per_example * batch_size
         hidden_preactivation_Bh = rearrange(hidden_preactivation_BH, "batch hidden -> (batch hidden)")
         _topk_values_Bh, topk_indices_Bh = hidden_preactivation_Bh.topk(k=batch_k)
         hidden_Bh = t.zeros_like(hidden_preactivation_Bh)
@@ -170,7 +170,7 @@ def build_batch_topk_crosscoder(
     n_layers: int,
     d_model: int,
     cc_hidden_dim: int,
-    k: int,
+    k_per_example: int,
     dec_init_norm: float,
 ) -> AcausalCrosscoder:
     return AcausalCrosscoder(
@@ -179,7 +179,7 @@ def build_batch_topk_crosscoder(
         d_model=d_model,
         hidden_dim=cc_hidden_dim,
         dec_init_norm=dec_init_norm,
-        hidden_activation=BatchTopkActivation(k=k),
+        hidden_activation=BatchTopkActivation(k_per_example=k_per_example),
     )
 
 

--- a/model_diffing/models/crosscoder.py
+++ b/model_diffing/models/crosscoder.py
@@ -32,7 +32,6 @@ class TopkActivation(nn.Module):
         return hidden_BH
 
 
-# ! this is not tested yet
 class BatchTopkActivation(nn.Module):
     def __init__(self, k_per_example: int):
         super().__init__()

--- a/model_diffing/scripts/trainer.py
+++ b/model_diffing/scripts/trainer.py
@@ -118,12 +118,13 @@ class BaseTrainer[TConfig: BaseTrainConfig]:
                     and self.cfg.save_every_n_steps is not None
                     and self.step % self.cfg.save_every_n_steps == 0
                 ):
-                    save_model_and_config(
-                        config=self.cfg,
-                        save_dir=self.save_dir,
-                        model=self.crosscoder,
-                        epoch=self.step,
-                    )
+                    with self.crosscoder.temporary_fold(norm_scaling_factors_ML):
+                        save_model_and_config(
+                            config=self.cfg,
+                            save_dir=self.save_dir,
+                            model=self.crosscoder,
+                            epoch=self.step,
+                        )
 
                 if self.epoch == 0:
                     self.unique_tokens_trained += batch_BMLD.shape[0]

--- a/tests/test_crosscoder.py
+++ b/tests/test_crosscoder.py
@@ -26,6 +26,7 @@ def test_return_shapes():
     assert train_res.reconstructed_acts_BMLD.shape == activations_BMLD.shape
     assert train_res.hidden_BH.shape == (batch_size, cc_hidden_dim)
 
+
 def test_batch_topk_activation():
     batch_topk_activation = BatchTopkActivation(k_per_example=2)
     hidden_preactivation_BH = t.tensor([[1, 2, 3, 4, 10], [1, 2, 11, 12, 13]])

--- a/tests/test_crosscoder.py
+++ b/tests/test_crosscoder.py
@@ -33,3 +33,57 @@ def test_batch_topk_activation():
     hidden_BH = batch_topk_activation.forward(hidden_preactivation_BH)
     assert hidden_BH.shape == hidden_preactivation_BH.shape
     assert t.all(hidden_BH == t.tensor([[0, 0, 0, 0, 10], [0, 0, 11, 12, 13]]))
+
+
+def test_weights_folding_keeps_hidden_representations_consistent():
+    batch_size = 4
+    n_models = 2
+    n_layers = 6
+    d_model = 16
+    cc_hidden_dim = 256
+    dec_init_norm = 1
+
+    crosscoder = build_relu_crosscoder(n_models, n_layers, d_model, cc_hidden_dim, dec_init_norm)
+
+    scaling_factors_ML = t.randn(n_models, n_layers)
+
+    unscaled_input_BMLD = t.randn(batch_size, n_models, n_layers, d_model)
+    scaled_input_BMLD = unscaled_input_BMLD * scaling_factors_ML[..., None]
+
+    output_without_folding = crosscoder.forward_train(scaled_input_BMLD)
+
+    with crosscoder.temporary_fold(scaling_factors_ML):
+        output_with_folding = crosscoder.forward_train(unscaled_input_BMLD)
+
+    output_after_unfolding = crosscoder.forward_train(scaled_input_BMLD)
+
+    # all hidden representations should be the same
+    assert t.allclose(output_without_folding.hidden_BH, output_with_folding.hidden_BH)
+    assert t.allclose(output_without_folding.hidden_BH, output_after_unfolding.hidden_BH)
+
+
+def test_weights_folding_scales_output_correctly():
+    batch_size = 2
+    n_models = 3
+    n_layers = 4
+    d_model = 5
+    cc_hidden_dim = 6
+    dec_init_norm = 0.1
+
+    crosscoder = build_relu_crosscoder(n_models, n_layers, d_model, cc_hidden_dim, dec_init_norm)
+
+    scaling_factors_ML = t.randn(n_models, n_layers)
+
+    unscaled_input_BMLD = t.randn(batch_size, n_models, n_layers, d_model)
+    scaled_input_BMLD = unscaled_input_BMLD * scaling_factors_ML[..., None]
+
+    scaled_output_BMLD = crosscoder.forward_train(scaled_input_BMLD).reconstructed_acts_BMLD
+
+    crosscoder.fold_activation_scaling_into_weights_(scaling_factors_ML)
+    unscaled_output_folded_BMLD = crosscoder.forward_train(unscaled_input_BMLD).reconstructed_acts_BMLD
+    scaled_output_folded_BMLD = unscaled_output_folded_BMLD * scaling_factors_ML[..., None]
+
+    # with folded weights, the output should be scaled by the scaling factors
+    assert t.allclose(scaled_output_BMLD, scaled_output_folded_BMLD), (
+        f"max diff: {t.max(t.abs(scaled_output_BMLD - scaled_output_folded_BMLD))}"
+    )

--- a/tests/test_crosscoder.py
+++ b/tests/test_crosscoder.py
@@ -1,6 +1,6 @@
 import torch as t
 
-from model_diffing.models.crosscoder import build_relu_crosscoder
+from model_diffing.models.crosscoder import BatchTopkActivation, build_relu_crosscoder
 
 
 def test_return_shapes():
@@ -25,3 +25,10 @@ def test_return_shapes():
     train_res = crosscoder.forward_train(activations_BMLD)
     assert train_res.reconstructed_acts_BMLD.shape == activations_BMLD.shape
     assert train_res.hidden_BH.shape == (batch_size, cc_hidden_dim)
+
+def test_batch_topk_activation():
+    batch_topk_activation = BatchTopkActivation(k_per_example=2)
+    hidden_preactivation_BH = t.tensor([[1, 2, 3, 4, 10], [1, 2, 11, 12, 13]])
+    hidden_BH = batch_topk_activation.forward(hidden_preactivation_BH)
+    assert hidden_BH.shape == hidden_preactivation_BH.shape
+    assert t.all(hidden_BH == t.tensor([[0, 0, 0, 0, 10], [0, 0, 11, 12, 13]]))


### PR DESCRIPTION
## Description
adds the ability to fold activation scaling parameters into the model weights, in line with standard practice in [SAELens](https://github.com/jbloomAus/SAELens/blob/36dab85319464218500963bd7159e6ace6cbf230/sae_lens/sae.py#L475-L485) and [dictionary_learning](https://github.com/saprmarks/dictionary_learning/blob/main/dictionary.py#L99-L101).

I do make one change (hopefully improvement) by storing the activation scaling parameters in a buffer on the crosscoder. This allows the operation to be undone, and makes these parameters automatically persisted whenever the model is (for example, in a checkpoint). I think this is nice because one can load the trained crosscoder with folded-in scaling params, unfold the params, and continue training, without having to scale hyperparameters to account for model weights scaling