### PR TITLE
fix jan update bias initialization

### DIFF
--- a/model_diffing/scripts/base_trainer.py
+++ b/model_diffing/scripts/base_trainer.py
@@ -8,6 +8,7 @@ from typing import Any, Generic, TypeVar
 import torch
 import wandb
 import yaml  # type: ignore
+from pydantic import BaseModel
 from tqdm import tqdm  # type: ignore
 from wandb.sdk.wandb_run import Run
 
@@ -20,10 +21,10 @@ from model_diffing.scripts.utils import build_lr_scheduler, build_optimizer, wan
 from model_diffing.utils import SaveableModule
 
 
-def save_config(config: BaseTrainConfig, save_dir: Path) -> None:
+def save_config(config: BaseModel, save_dir: Path) -> None:
     save_dir.mkdir(parents=True, exist_ok=True)
     with open(save_dir / "config.yaml", "w") as f:
-        yaml.dump(config, f)
+        yaml.dump(config.model_dump(), f)
     logger.info(f"Saved config to {save_dir / 'config.yaml'}")
 
 

--- a/model_diffing/scripts/config_common.py
+++ b/model_diffing/scripts/config_common.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from operator import xor
-from typing import Any
+from typing import Any, Literal
 
 from model_diffing.utils import BaseModel
 
@@ -54,10 +54,15 @@ class BaseTrainConfig(BaseModel):
             raise ValueError("must provide either only epochs and num_steps_per_epoch or only num_steps")
 
 
+class WandbConfig(BaseModel):
+    entity: str = "mars-model-diffing"
+    project: str = "model-diffing"
+
+
 class BaseExperimentConfig(BaseModel):
     seed: int = 42
     cache_dir: str = ".cache"
-    wandb: bool
+    wandb: WandbConfig | Literal["disabled"] = WandbConfig()
     experiment_name: str
 
     def model_post_init(self, __context: Any) -> None:

--- a/model_diffing/scripts/skip_trans_crosscoder/example_config.yaml
+++ b/model_diffing/scripts/skip_trans_crosscoder/example_config.yaml
@@ -22,5 +22,4 @@ train:
   save_every_n_steps: 2500
   log_every_n_steps: 100
 experiment_name: skip_trans_crosscoder_example
-wandb: true
 mlp_indices: [7]

--- a/model_diffing/scripts/skip_trans_crosscoder/run.py
+++ b/model_diffing/scripts/skip_trans_crosscoder/run.py
@@ -63,7 +63,7 @@ def build_trainer(cfg: TopkSkipTransCrosscoderExperimentConfig) -> TopkSkipTrans
 
     crosscoder = crosscoder.to(device)
 
-    wandb_run = build_wandb_run(cfg) if cfg.wandb else None
+    wandb_run = build_wandb_run(cfg)
 
     return TopkSkipTransCrosscoderTrainer(
         cfg=cfg.train,

--- a/model_diffing/scripts/skip_trans_crosscoder/trainer.py
+++ b/model_diffing/scripts/skip_trans_crosscoder/trainer.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterator
-from itertools import islice
 from typing import Any
 
 import torch

--- a/model_diffing/scripts/train_jan_update_crosscoder/config.py
+++ b/model_diffing/scripts/train_jan_update_crosscoder/config.py
@@ -1,3 +1,11 @@
+from typing import Any
+
+from typing import Any
+
+from typing import Any
+
+from typing import Any
+
 from model_diffing.scripts.config_common import BaseExperimentConfig, BaseTrainConfig, DataConfig
 from model_diffing.utils import BaseModel
 
@@ -7,10 +15,40 @@ class JumpReLUConfig(BaseModel):
     threshold_init: float = 0.1  # aka t
     backprop_through_jumprelu_input: bool = False
 
+    initial_approx_firing_pct: float
+    """
+    The initial approximate firing percentage of the jumprelu, as a float between 0 and 1. This is used to calibrate
+    b_enc. In the update, this value is 10_000 / hidden_size. But we're often training with hidden_size << 10_000, so
+    we allow setting this value directly.
+    
+    Sensible values might be something like 0.2 - 0.8, but I'm (oli) very uncertain about this!
+
+    see: https://transformer-circuits.pub/2025/january-update/index.html#:~:text=.-,We%20initialize,-%F0%9D%91%8F
+    """
+
+    def model_post_init(self, __context: Any) -> None:
+        super().model_post_init(__context)
+        if self.initial_approx_firing_pct > 1 or self.initial_approx_firing_pct < 0:
+            raise ValueError(f"initial_approx_firing_pct must be between 0 and 1, got {self.initial_approx_firing_pct}")
 
 class JanUpdateCrosscoderConfig(BaseModel):
     hidden_dim: int
     jumprelu: JumpReLUConfig = JumpReLUConfig()
+    initial_approx_firing_pct: float
+    """
+    The initial approximate firing percentage of the jumprelu, as a float between 0 and 1. This is used to calibrate
+    b_enc. In the update, this value is 10_000 / hidden_size. But we're often training with hidden_size << 10_000, so
+    we allow setting this value directly.
+    
+    Sensible values might be something like 0.2 - 0.8, but I'm (oli) very uncertain about this!
+
+    see: https://transformer-circuits.pub/2025/january-update/index.html#:~:text=.-,We%20initialize,-%F0%9D%91%8F
+    """
+
+    def model_post_init(self, __context: Any) -> None:
+        super().model_post_init(__context)
+        if self.initial_approx_firing_pct > 1 or self.initial_approx_firing_pct < 0:
+            raise ValueError(f"initial_approx_firing_pct must be between 0 and 1, got {self.initial_approx_firing_pct}")
 
 
 class JanUpdateTrainConfig(BaseTrainConfig):

--- a/model_diffing/scripts/train_jan_update_crosscoder/config.py
+++ b/model_diffing/scripts/train_jan_update_crosscoder/config.py
@@ -1,11 +1,5 @@
 from typing import Any
 
-from typing import Any
-
-from typing import Any
-
-from typing import Any
-
 from model_diffing.scripts.config_common import BaseExperimentConfig, BaseTrainConfig, DataConfig
 from model_diffing.utils import BaseModel
 
@@ -15,21 +9,6 @@ class JumpReLUConfig(BaseModel):
     threshold_init: float = 0.1  # aka t
     backprop_through_jumprelu_input: bool = False
 
-    initial_approx_firing_pct: float
-    """
-    The initial approximate firing percentage of the jumprelu, as a float between 0 and 1. This is used to calibrate
-    b_enc. In the update, this value is 10_000 / hidden_size. But we're often training with hidden_size << 10_000, so
-    we allow setting this value directly.
-    
-    Sensible values might be something like 0.2 - 0.8, but I'm (oli) very uncertain about this!
-
-    see: https://transformer-circuits.pub/2025/january-update/index.html#:~:text=.-,We%20initialize,-%F0%9D%91%8F
-    """
-
-    def model_post_init(self, __context: Any) -> None:
-        super().model_post_init(__context)
-        if self.initial_approx_firing_pct > 1 or self.initial_approx_firing_pct < 0:
-            raise ValueError(f"initial_approx_firing_pct must be between 0 and 1, got {self.initial_approx_firing_pct}")
 
 class JanUpdateCrosscoderConfig(BaseModel):
     hidden_dim: int

--- a/model_diffing/scripts/train_jan_update_crosscoder/example_config.yaml
+++ b/model_diffing/scripts/train_jan_update_crosscoder/example_config.yaml
@@ -17,6 +17,7 @@ crosscoder:
   hidden_dim: 4096
   jumprelu:
     backprop_through_jumprelu_input: true
+  initial_approx_firing_pct: 0.5 # WARNING(oli): very uncertain this is a good default!
 train:
   num_steps: 10_000
   batch_size: 32

--- a/model_diffing/scripts/train_jan_update_crosscoder/example_config.yaml
+++ b/model_diffing/scripts/train_jan_update_crosscoder/example_config.yaml
@@ -27,5 +27,4 @@ train:
   final_lambda_s: 5.0
   lambda_p: 0.000003
 experiment_name: jan_update_crosscoder_example
-wandb: true
 hookpoints: ["blocks.8.hook_resid_post"]

--- a/model_diffing/scripts/train_jan_update_crosscoder/run.py
+++ b/model_diffing/scripts/train_jan_update_crosscoder/run.py
@@ -58,7 +58,7 @@ def build_jan_update_crosscoder_trainer(cfg: JanUpdateExperimentConfig) -> JanUp
     )
     crosscoder = crosscoder.to(device)
 
-    wandb_run = build_wandb_run(cfg) if cfg.wandb else None
+    wandb_run = build_wandb_run(cfg)
 
     return JanUpdateCrosscoderTrainer(
         cfg=cfg.train,

--- a/model_diffing/scripts/train_jan_update_crosscoder/run.py
+++ b/model_diffing/scripts/train_jan_update_crosscoder/run.py
@@ -6,13 +6,13 @@ import torch
 from einops import rearrange
 from tqdm import tqdm  # type: ignore
 
-from model_diffing.data.model_hookpoint_dataloader import BaseModelHookpointActivationsDataloader, build_dataloader
+from model_diffing.data.model_hookpoint_dataloader import build_dataloader
 from model_diffing.log import logger
 from model_diffing.models.activations import JumpReLUActivation
 from model_diffing.models.crosscoder import AcausalCrosscoder, InitStrategy
 from model_diffing.scripts.base_trainer import run_exp
 from model_diffing.scripts.llms import build_llms
-from model_diffing.scripts.train_jan_update_crosscoder.config import JanUpdateExperimentConfig, JumpReLUConfig
+from model_diffing.scripts.train_jan_update_crosscoder.config import JanUpdateExperimentConfig
 from model_diffing.scripts.train_jan_update_crosscoder.trainer import JanUpdateCrosscoderTrainer
 from model_diffing.scripts.utils import build_wandb_run
 from model_diffing.utils import get_device, inspect, round_up
@@ -40,14 +40,21 @@ def build_jan_update_crosscoder_trainer(cfg: JanUpdateExperimentConfig) -> JanUp
     n_models = len(llms)
     n_hookpoints = len(cfg.hookpoints)
 
-    crosscoder = _build_jan_update_crosscoder(
-        n_models=n_models,
-        n_hookpoints=n_hookpoints,
+    crosscoder = AcausalCrosscoder(
+        crosscoding_dims=(n_models, n_hookpoints),
         d_model=llms[0].cfg.d_model,
-        cc_hidden_dim=cfg.crosscoder.hidden_dim,
-        jumprelu=cfg.crosscoder.jumprelu,
-        data_loader=dataloader,
-        device=device,
+        hidden_dim=cfg.crosscoder.hidden_dim,
+        init_strategy=JanUpdateInitStrategy(
+            activations_iterator_BXD=dataloader.get_shuffled_activations_iterator_BMPD(),
+            initial_approx_firing_pct=cfg.crosscoder.initial_approx_firing_pct,
+            n_examples_to_sample=100_000,
+        ),
+        hidden_activation=JumpReLUActivation(
+            size=cfg.crosscoder.hidden_dim,
+            bandwidth=cfg.crosscoder.jumprelu.bandwidth,
+            threshold_init=cfg.crosscoder.jumprelu.threshold_init,
+            backprop_through_input=cfg.crosscoder.jumprelu.backprop_through_jumprelu_input,
+        ),
     )
     crosscoder = crosscoder.to(device)
 
@@ -64,120 +71,118 @@ def build_jan_update_crosscoder_trainer(cfg: JanUpdateExperimentConfig) -> JanUp
     )
 
 
-def _build_jan_update_crosscoder(
-    n_models: int,
-    n_hookpoints: int,
-    d_model: int,
-    cc_hidden_dim: int,
-    jumprelu: JumpReLUConfig,
-    data_loader: BaseModelHookpointActivationsDataloader,
-    device: torch.device,  # for computing b_enc
-) -> AcausalCrosscoder[JumpReLUActivation]:
-    cc = AcausalCrosscoder(
-        crosscoding_dims=(n_models, n_hookpoints),
-        d_model=d_model,
-        hidden_dim=cc_hidden_dim,
-        init_strategy=JanUpdateInitStrategy(
-            activations_iterator_BXD=data_loader.get_shuffled_activations_iterator_BMPD(),
-            device=device,
-            n_examples_to_sample=100_000,
-            firing_sparsity=10_000,
-        ),
-        hidden_activation=JumpReLUActivation(
-            size=cc_hidden_dim,
-            bandwidth=jumprelu.bandwidth,
-            threshold_init=jumprelu.threshold_init,
-            backprop_through_input=jumprelu.backprop_through_jumprelu_input,
-        ),
-    )
-
-    cc.to(device)
-
-    return cc
-
-
 class JanUpdateInitStrategy(InitStrategy[JumpReLUActivation]):
     def __init__(
         self,
         activations_iterator_BXD: Iterator[torch.Tensor],
-        device: torch.device,
+        initial_approx_firing_pct: float,
         n_examples_to_sample: int = 100_000,
-        firing_sparsity: float = 10_000,
     ):
+        """
+        Args:
+            activations_iterator_BXD: iterator over activations with which to calibrate the initial jumprelu threshold
+            initial_approx_firing_pct: percentage of examples that should fire. In the update, this value is 10_000 / n. But we're often training with n << 10_000, so we allow setting this value directly.
+            n_examples_to_sample: number of examples to sample
+        """
         self.activations_iterator_BXD = activations_iterator_BXD
-        self.device = device
         self.n_examples_to_sample = n_examples_to_sample
-        self.firing_sparsity = firing_sparsity
 
+        if initial_approx_firing_pct < 0 or initial_approx_firing_pct > 1:
+            raise ValueError(f"initial_approx_firing_pct must be between 0 and 1, got {initial_approx_firing_pct}")
+        self.initial_approx_firing_pct = initial_approx_firing_pct
+
+    @torch.no_grad()
     def init_weights(self, cc: AcausalCrosscoder[JumpReLUActivation]) -> None:
+        ## cc is on CPU atm, but the dataloader is on GPU
         n = prod(cc.crosscoding_dims) * cc.d_model
         m = cc.hidden_dim
 
-        cc.W_dec_HXD.uniform_(-1.0 / n, 1.0 / n)
-        cc.W_enc_XDH.copy_(
+        cc.W_dec_HXD.data.uniform_(-1.0 / n, 1.0 / n)
+        cc.W_enc_XDH.data.copy_(
             rearrange(cc.W_dec_HXD, "hidden ... -> ... hidden")  #
             * (n / m)
         )
 
-        calibrated_b_enc_H = self.compute_b_enc_H(
+        calibrated_b_enc_H = compute_b_enc_H(
+            self.activations_iterator_BXD,
             cc.W_enc_XDH,
             cc.hidden_activation.log_threshold_H.exp(),
+            self.initial_approx_firing_pct,
+            self.n_examples_to_sample,
         )
 
-        cc.b_enc_H.copy_(calibrated_b_enc_H)
+        cc.b_enc_H.data.copy_(calibrated_b_enc_H)
 
-        cc.b_dec_XD.zero_()
+        cc.b_dec_XD.data.zero_()
 
-    def compute_b_enc_H(self, W_enc_XDH: torch.Tensor, initial_jumprelu_threshold_H: torch.Tensor) -> torch.Tensor:
-        logger.info(f"Harvesting pre-bias for {self.n_examples_to_sample} examples")
 
-        pre_bias_NH = self.harvest_pre_bias_NH(W_enc_XDH)
+def compute_b_enc_H(
+    activations_iterator_BXD: Iterator[torch.Tensor],
+    W_enc_XDH: torch.Tensor,
+    initial_jumprelu_threshold_H: torch.Tensor,
+    initial_approx_firing_pct: float,
+    n_examples_to_sample: int,
+) -> torch.Tensor:
+    logger.info(f"Harvesting pre-bias for {n_examples_to_sample} examples")
 
-        # find the threshold for each idx H such that 1/10_000 of the examples are above the threshold
-        quantile_H = torch.quantile(pre_bias_NH, 1 - 1 / self.firing_sparsity, dim=0)
+    # pre-bias is just x @ W
+    pre_bias_NH = _harvest_pre_bias_NH(W_enc_XDH, activations_iterator_BXD, n_examples_to_sample)
 
-        # firing is when the post-bias is above the jumprelu threshold therefore, we subtract
-        # the quantile from the initial jumprelu threshold, such the 1/firing_sparsity of the
-        # examples are above the threshold
-        b_enc_H = initial_jumprelu_threshold_H - quantile_H
+    pre_bias_firing_threshold_quantile_H = torch.quantile(
+        pre_bias_NH,
+        1 - initial_approx_firing_pct,
+        dim=0,
+    )
 
-        logger.info(f"computed b_enc_H. Sample: {b_enc_H[:10]}. mean: {b_enc_H.mean()}, std: {b_enc_H.std()}")
+    # firing is when the post-bias is above the jumprelu threshold, therefore we subtract
+    # the quantile from the initial jumprelu threshold, so that for a given example,
+    # inital_approx_firing_pct of the examples are above the threshold.
+    b_enc_H = initial_jumprelu_threshold_H - pre_bias_firing_threshold_quantile_H
 
-        return b_enc_H
+    logger.info(f"computed b_enc_H. Sample: {b_enc_H[:10]}. mean: {b_enc_H.mean()}, std: {b_enc_H.std()}")
 
-    def harvest_pre_bias_NH(self, W_enc_XDH: torch.Tensor) -> torch.Tensor:
-        def get_batch_pre_bias() -> torch.Tensor:
-            # this is essentially the first step of the crosscoder forward pass, but not worth
-            # creating a new method for it, just (easily) reimplementing it here
-            batch_BXD = next(self.activations_iterator_BXD)
-            x_BH = torch.einsum("b ... d, ... d h -> b h", batch_BXD, W_enc_XDH)
-            return x_BH
+    return b_enc_H
 
-        sample_BH = get_batch_pre_bias()
-        batch_size, hidden_size = sample_BH.shape
 
-        rounded_n_examples_to_sample = round_up(self.n_examples_to_sample, to_multiple_of=batch_size)
+def _harvest_pre_bias_NH(
+    W_enc_XDH: torch.Tensor,
+    activations_iterator_BXD: Iterator[torch.Tensor],
+    n_examples_to_sample: int,
+) -> torch.Tensor:
+    cc_device = W_enc_XDH.device
 
-        if rounded_n_examples_to_sample > self.n_examples_to_sample:
-            logger.warning(
-                f"rounded n_examples_to_sample from {self.n_examples_to_sample} to {rounded_n_examples_to_sample} "
-                f"to be divisible by the batch size {batch_size}"
-            )
+    def get_batch_pre_bias() -> torch.Tensor:
+        # this is essentially the first step of the crosscoder forward pass, but not worth
+        # creating a new method for it, just (easily) reimplementing it here
+        batch_BXD = next(activations_iterator_BXD).to(cc_device)
+        x_BH = torch.einsum("b ... d, ... d h -> b h", batch_BXD, W_enc_XDH)
+        return x_BH
 
-        num_batches = rounded_n_examples_to_sample // batch_size
+    sample_BH = get_batch_pre_bias()
+    batch_size, hidden_size = sample_BH.shape
 
-        pre_bias_buffer_NH = torch.empty(rounded_n_examples_to_sample, hidden_size, device=self.device)
-        logger.info(f"pre_bias_buffer_NH: {inspect(pre_bias_buffer_NH)}")
+    rounded_n_examples_to_sample = round_up(n_examples_to_sample, to_multiple_of=batch_size)
 
-        pre_bias_buffer_NH[:batch_size] = sample_BH
+    if rounded_n_examples_to_sample > n_examples_to_sample:
+        logger.warning(
+            f"rounded n_examples_to_sample from {n_examples_to_sample} to {rounded_n_examples_to_sample} "
+            f"to be divisible by the batch size {batch_size}"
+        )
 
-        for i in tqdm(
-            range(1, num_batches), desc="Harvesting pre-bias"
-        ):  # start at 1 because we already sampled the first batch
-            batch_pre_bias_BH = get_batch_pre_bias()
-            pre_bias_buffer_NH[batch_size * i : batch_size * (i + 1)] = batch_pre_bias_BH
+    num_batches = rounded_n_examples_to_sample // batch_size
 
-        return pre_bias_buffer_NH
+    pre_bias_buffer_NH = torch.empty(rounded_n_examples_to_sample, hidden_size, device=cc_device)
+    logger.info(f"pre_bias_buffer_NH: {inspect(pre_bias_buffer_NH)}")
+
+    pre_bias_buffer_NH[:batch_size] = sample_BH
+
+    for i in tqdm(
+        range(1, num_batches), desc="Harvesting pre-bias"
+    ):  # start at 1 because we already sampled the first batch
+        batch_pre_bias_BH = get_batch_pre_bias()
+        pre_bias_buffer_NH[batch_size * i : batch_size * (i + 1)] = batch_pre_bias_BH
+
+    return pre_bias_buffer_NH
 
 
 if __name__ == "__main__":

--- a/model_diffing/scripts/train_jumprelu_sliding_window/example_config.yaml
+++ b/model_diffing/scripts/train_jumprelu_sliding_window/example_config.yaml
@@ -16,6 +16,7 @@ crosscoder:
   hidden_dim: 4096
   jumprelu:
     backprop_through_jumprelu_input: true
+  initial_approx_firing_pct: 0.5 # WARNING(oli): very uncertain this is a good default!
 train:
   num_steps: 10_000
   batch_size: 32

--- a/model_diffing/scripts/train_jumprelu_sliding_window/example_config.yaml
+++ b/model_diffing/scripts/train_jumprelu_sliding_window/example_config.yaml
@@ -26,7 +26,6 @@ train:
   final_lambda_s: 5.0
   lambda_p: 0.000003 # 3e-6
 experiment_name: sliding_window_test
-wandb: True
 hookpoints:
   - "blocks.0.hook_resid_post"
   - "blocks.1.hook_resid_post"

--- a/model_diffing/scripts/train_jumprelu_sliding_window/run.py
+++ b/model_diffing/scripts/train_jumprelu_sliding_window/run.py
@@ -57,7 +57,7 @@ def _build_sliding_window_crosscoder_trainer(
             ),
             init_strategy=JanUpdateInitStrategy(
                 activations_iterator_BXD=dataloader.get_shuffled_activations_iterator_BTPD(),
-                device=device,
+                initial_approx_firing_pct=cfg.crosscoder.initial_approx_firing_pct,
             ),
         )
         for window_size in [1, 2]

--- a/model_diffing/scripts/train_jumprelu_sliding_window/run.py
+++ b/model_diffing/scripts/train_jumprelu_sliding_window/run.py
@@ -66,7 +66,7 @@ def _build_sliding_window_crosscoder_trainer(
     crosscoders = BiTokenCCWrapper(crosscoder1, crosscoder2)
     crosscoders.to(device)
 
-    wandb_run = build_wandb_run(cfg) if cfg.wandb else None
+    wandb_run = build_wandb_run(cfg)
 
     return JumpreluSlidingWindowCrosscoderTrainer(
         cfg=cfg.train,

--- a/model_diffing/scripts/train_l1_crosscoder/example_config.yaml
+++ b/model_diffing/scripts/train_l1_crosscoder/example_config.yaml
@@ -25,5 +25,4 @@ train:
   save_every_n_steps: 1000
   log_every_n_steps: 20
 experiment_name: l1_crosscoder_example
-wandb: True
 hookpoints: ["blocks.8.hook_resid_post"]

--- a/model_diffing/scripts/train_l1_crosscoder/run.py
+++ b/model_diffing/scripts/train_l1_crosscoder/run.py
@@ -44,7 +44,7 @@ def build_l1_crosscoder_trainer(cfg: L1ExperimentConfig) -> L1CrosscoderTrainer:
 
     crosscoder = crosscoder.to(device)
 
-    wandb_run = build_wandb_run(cfg) if cfg.wandb else None
+    wandb_run = build_wandb_run(cfg)
 
     return L1CrosscoderTrainer(
         cfg=cfg.train,

--- a/model_diffing/scripts/train_l1_sliding_window/example_config.yaml
+++ b/model_diffing/scripts/train_l1_sliding_window/example_config.yaml
@@ -23,7 +23,6 @@ train:
   lambda_s_max: 5.0
   lambda_s_n_steps: 10_000
 experiment_name: l1_sliding_window_example
-wandb: true
 hookpoints:
   - "blocks.0.hook_resid_post"
   - "blocks.1.hook_resid_post"

--- a/model_diffing/scripts/train_l1_sliding_window/run.py
+++ b/model_diffing/scripts/train_l1_sliding_window/run.py
@@ -52,7 +52,7 @@ def _build_sliding_window_crosscoder_trainer(cfg: L1SlidingWindowExperimentConfi
     crosscoders = BiTokenCCWrapper(crosscoder1, crosscoder2)
     crosscoders.to(device)
 
-    wandb_run = build_wandb_run(cfg) if cfg.wandb else None
+    wandb_run = build_wandb_run(cfg)
 
     return L1SlidingWindowCrosscoderTrainer(
         cfg=cfg.train,

--- a/model_diffing/scripts/train_topk_crosscoder/example_config.yaml
+++ b/model_diffing/scripts/train_topk_crosscoder/example_config.yaml
@@ -22,5 +22,4 @@ train:
   save_every_n_steps: 2500
   log_every_n_steps: 100
 experiment_name: topk_crosscoder_example
-wandb: true
 hookpoints: ["blocks.8.hook_resid_post"]

--- a/model_diffing/scripts/train_topk_crosscoder/run.py
+++ b/model_diffing/scripts/train_topk_crosscoder/run.py
@@ -45,7 +45,7 @@ def build_trainer(cfg: TopKExperimentConfig) -> TopKTrainer:
 
     crosscoder = crosscoder.to(device)
 
-    wandb_run = build_wandb_run(cfg) if cfg.wandb else None
+    wandb_run = build_wandb_run(cfg)
 
     return TopKTrainer(
         cfg=cfg.train,

--- a/model_diffing/scripts/utils.py
+++ b/model_diffing/scripts/utils.py
@@ -59,10 +59,12 @@ def wandb_histogram(data_X: torch.Tensor | np.ndarray[Any, Any], bins: int = 100
 
 
 def build_wandb_run(config: BaseExperimentConfig) -> Run | None:
+    if config.wandb == "disabled":
+        return None
     return wandb.init(
         name=config.experiment_name,
-        project="model-diffing",
-        entity="mars-model-diffing",
+        project=config.wandb.project,
+        entity=config.wandb.entity,
         config=config.model_dump(),
     )
 

--- a/tests/test_jan_update_init.py
+++ b/tests/test_jan_update_init.py
@@ -1,0 +1,78 @@
+import torch
+
+from model_diffing.scripts.train_jan_update_crosscoder.run import compute_b_enc_H
+
+
+def test_compute_b_enc_H():
+    hidden_dim = 2
+
+    # use an identity matrix for the encoder weights so that the pre-bias is just the feature values
+    W_enc_XDH = torch.eye(hidden_dim).float()
+
+    initial_approx_firing_pct = 0.25
+
+    batch_BD = torch.tensor(
+        [
+            [0, 4],
+            [1, 5],
+            [2, 6],
+            # this is where the threshold should be drawn. 25% of the examples should fire, i.e. just the example [3, 7]
+            [3, 7],
+        ]
+    ).float()
+
+    activations_iterator_BD = iter([batch_BD, batch_BD.clone()])
+
+    # use a jumprelu threshold of 1.0 for simplicity
+    initial_jumprelu_threshold_H = torch.ones(hidden_dim).float()
+
+    b_enc_H = compute_b_enc_H(
+        activations_iterator_BD,
+        W_enc_XDH,
+        initial_jumprelu_threshold_H,
+        initial_approx_firing_pct,
+        n_examples_to_sample=8,  # just the size of the dataset (2 batches of 4 examples each)
+    )
+
+    assert b_enc_H.shape == (hidden_dim,)
+
+    # the threshold should be the 75th percentile of the pre-bias values, minus the jumprelu threshold
+    # - 75th quantile of the pre-bias values is [2.25, 6.25] (see linear interpolation in torch.quantile)
+    # - the jumprelu threshold is 1.0, so the threshold is 1 - [2.25, 6.25]
+    expected_b_enc_H = torch.tensor([1 - 2.25, 1 - 6.25])
+    assert torch.allclose(b_enc_H, expected_b_enc_H), f"b_enc_H: {b_enc_H}, expected_b_enc_H: {expected_b_enc_H}"
+
+
+test_compute_b_enc_H()
+
+
+def test_compute_b_enc_H_batches_rounding():
+    hidden_dim = 1
+
+    # use an identity matrix for the encoder weights so that the pre-bias is just the feature values
+    W_enc_XDH = torch.eye(hidden_dim).float()  # this is just [1.], but wanting to make the identity transform explicit
+
+    initial_approx_firing_pct = 0.25
+
+    batch_1_BD = torch.tensor([[0], [1], [2]]).float()
+    batch_2_BD = torch.tensor([[3], [4], [5]]).float()
+
+    activations_iterator_BD = iter([batch_1_BD, batch_2_BD])
+
+    initial_jumprelu_threshold_H = torch.randn(hidden_dim).float()
+
+    b_enc_H = compute_b_enc_H(
+        activations_iterator_BD,
+        W_enc_XDH,
+        initial_jumprelu_threshold_H,
+        initial_approx_firing_pct,
+        n_examples_to_sample=5,  # should round up to 6 (taking in both batches)
+    )
+
+    assert b_enc_H.shape == (hidden_dim,)
+
+    # the threshold should be the 75th percentile of the pre-bias values, minus the jumprelu threshold
+    whole_dataset_BD = torch.cat([batch_1_BD, batch_2_BD])
+    expected_b_enc_H = initial_jumprelu_threshold_H - torch.quantile(whole_dataset_BD, 1 - initial_approx_firing_pct)
+
+    assert torch.allclose(b_enc_H, expected_b_enc_H), f"b_enc_H: {b_enc_H}, expected_b_enc_H: {expected_b_enc_H}"


### PR DESCRIPTION
- Fixes the encoder bias initialisation in the jan update training recipe.
- Fixes a tensor `device` bug
- Fixes serialization of configs (plain yaml now, no special tags)
- Makes wandb entity and project dynamic so Jason's stream can use it easily